### PR TITLE
Change to call URI.open and File.open directly

### DIFF
--- a/lib/wordmove/deployer/base.rb
+++ b/lib/wordmove/deployer/base.rb
@@ -100,11 +100,9 @@ module Wordmove
 
         return true if simulate?
 
-        # rubocop:todo Security/Open
-        open(local_path, 'w') do |file|
-          file << open(url).read
+        File.open(local_path, 'w') do |file|
+          file << URI.open(url).read
         end
-        # rubocop:enable Security/Open
       end
 
       def simulate?


### PR DESCRIPTION
Change to call URI.open and File.open directly to prevent rubocop Security/Open.

Related issues:
- https://github.com/rubocop-hq/rubocop/issues/6216
- https://github.com/rubocop-hq/rubocop/pull/6210

Also, in Ruby2.7, Kernel#open finally became deprecated.
- https://rubyreferences.github.io/rubychanges/2.7.html#network-and-web
- https://bugs.ruby-lang.org/issues/15893
